### PR TITLE
fix library libicu names

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -50,13 +50,13 @@ newoption {
 
 -- these are the ICU unicode string libraries (in Win32)
 ICU_LIBS_RELEASE = {
-       "icudt", "icuin", "icuio", "icule",
+       "icudata", "icui18n", "icuio", "icule",
        "iculx", "icutu", "icuuc"
 }
 
 -- these are the ICU unicode string libraries (in Win32)
 ICU_LIBS_DEBUG = {
-       "icudt", "icuind", "icuiod", "iculed",
+       "icudatad", "icui18nd", "icuiod", "iculed",
        "iculxd", "icutud", "icuucd"
 }
 


### PR DESCRIPTION
Seems like premake script have old names that can't be found