### PR TITLE
Fix a couple of crashes when parsing the AST.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,6 @@
  ##
 
 # script that compiles this project and runs the unit tests.
-./premake4-macosx  --icu-config=/usr/local/Cellar/icu4c/54.1/bin/icu-config gmake
+./premake4-macosx  --icu-config=/usr/local/Cellar/icu4c/58.2/bin/icu-config gmake
 cd build/gmake && make -j3
 cd ../../Debug && ./tests

--- a/src/ParserTypeClass.cpp
+++ b/src/ParserTypeClass.cpp
@@ -415,8 +415,9 @@ void pelet::AnyExpressionObserverClass::ExpressionAssignmentListFound(pelet::Ass
 		pelet::VariableClass var = expression->Destinations[i];
 		CheckExpression(&var);
 	}
-	
-	CheckExpression(expression->Expression);
+	if (expression->Expression) {
+		CheckExpression(expression->Expression);
+	}
 	OnAnyExpression(expression);
 }
 

--- a/tests/Parser55TestClass.cpp
+++ b/tests/Parser55TestClass.cpp
@@ -114,4 +114,37 @@ TEST_FIXTURE(Parser55FeaturesTestClass, ExpressionsInEmpty) {
 	CHECK(Parser.LintString(code, LintResults));
 }
 
+TEST_FIXTURE(Parser55FeaturesTestClass, ParserTernaryWithDefault) {
+	Parser.SetClassObserver(&Observer);
+	UnicodeString code = _U(
+		"<?php\n"
+		"class MyClass {\n"
+		"  function stop($name) {\n"
+		"    $this->name = $name ?: new MyClass(); \n"
+		"  }\n"
+		"}\n"
+	);
+	CHECK(Parser.ScanString(code, LintResults));
+	CHECK_VECTOR_SIZE(1, Observer.ClassName);
+	CHECK_UNISTR_EQUALS("MyClass", Observer.ClassName[0]);
+}
+
+TEST_FIXTURE(Parser55FeaturesTestClass, ParserClassStaticIndirectVariable) {
+	Parser.SetClassObserver(&Observer);
+	Parser.SetClassMemberObserver(&Observer);
+	Parser.SetVariableObserver(&Observer);
+	UnicodeString code = _U(
+		"<?php\n"
+		"class MyClass {\n"
+		"  function stop() {\n"
+		"    $this::$appname = null;\n"
+	    "	}\n"
+	    "}\n"
+    );
+
+	CHECK(Parser.ScanString(code, LintResults));
+	// not capturing indirect variables for now
+	CHECK_VECTOR_SIZE(0, Observer.VariableExpressions);
+}
+
 }


### PR DESCRIPTION
- Crash on ternary operators with a default clause:  `$n = $GET['name'] ?: 0`
- Crash on variable variable members:  `$this::$appname`