### PR TITLE
Find Variadic arguments inside methods/functions declared in namespaces.

### DIFF
--- a/src/FullParserObserverClass.cpp
+++ b/src/FullParserObserverClass.cpp
@@ -356,8 +356,24 @@ pelet::StatementListClass* pelet::FullParserObserverClass::ClassMemberSymbolMake
 	pelet::FunctionCallCountObserverClass callCount;
 	callCount.FunctionName = UNICODE_STRING_SIMPLE("func_get_arg");
 	hasVariableArguments |= callCount.CountCalls(functionStatements) > 0;
+	callCount.FunctionName = UNICODE_STRING_SIMPLE("\\func_get_arg");
+	hasVariableArguments |= callCount.CountCalls(functionStatements) > 0;
+	callCount.FunctionName = DeclaredNamespace.ToSignature() + UNICODE_STRING_SIMPLE("\\func_get_args");
+	hasVariableArguments |= callCount.CountCalls(functionStatements) > 0;
+
 	callCount.FunctionName = UNICODE_STRING_SIMPLE("func_get_args");
 	hasVariableArguments |= callCount.CountCalls(functionStatements) > 0;
+	callCount.FunctionName = UNICODE_STRING_SIMPLE("\\func_get_args");
+	hasVariableArguments |= callCount.CountCalls(functionStatements) > 0;
+
+	// functions that are not found in the declared namespace fallback to global
+	// function; but this parser will fully qualify global functions with
+	// the current namespace since the parser does not know which functions
+	// are global and which are not. End result is that we need to search the
+	// expressions for namespaced functions too
+	callCount.FunctionName = DeclaredNamespace.ToSignature() + UNICODE_STRING_SIMPLE("\\func_get_args");
+	hasVariableArguments |= callCount.CountCalls(functionStatements) > 0;
+
 
 	// variable arguments are also made with the ellipsis operator
 	for (size_t i = 0; i < parameters->GetCount(); i++) {
@@ -403,7 +419,22 @@ pelet::StatementListClass* pelet::FullParserObserverClass::ClassMemberSymbolMake
 	pelet::FunctionCallCountObserverClass callCount;
 	callCount.FunctionName = UNICODE_STRING_SIMPLE("func_get_arg");
 	hasVariableArguments |= callCount.CountCalls(&methodBody->MethodStatements) > 0;
+	callCount.FunctionName = UNICODE_STRING_SIMPLE("\\func_get_arg");
+	hasVariableArguments |= callCount.CountCalls(&methodBody->MethodStatements) > 0;
+	callCount.FunctionName = DeclaredNamespace.ToSignature() + UNICODE_STRING_SIMPLE("\\func_get_arg");
+	hasVariableArguments |= callCount.CountCalls(&methodBody->MethodStatements) > 0;
+
 	callCount.FunctionName = UNICODE_STRING_SIMPLE("func_get_args");
+	hasVariableArguments |= callCount.CountCalls(&methodBody->MethodStatements) > 0;
+	callCount.FunctionName = UNICODE_STRING_SIMPLE("\\func_get_args");
+	hasVariableArguments |= callCount.CountCalls(&methodBody->MethodStatements) > 0;
+
+	// functions that are not found in the declared namespace fallback to global
+	// function; but this parser will fully qualify global functions with
+	// the current namespace since the parser does not know which functions
+	// are global and which are not. End result is that we need to search the
+	// expressions for namespaced functions too
+	callCount.FunctionName = DeclaredNamespace.ToSignature() + UNICODE_STRING_SIMPLE("\\func_get_args");
 	hasVariableArguments |= callCount.CountCalls(&methodBody->MethodStatements) > 0;
 
 	// variable arguments are also made with the ellipsis operator

--- a/tests/ParserSharedTestClass.cpp
+++ b/tests/ParserSharedTestClass.cpp
@@ -715,6 +715,33 @@ TEST_FIXTURE(ParserStringSharedTestClass, ScanStringFunctionVariableArgsAndDefau
 	}
 }
 
+TEST_FIXTURE(ParserStringSharedTestClass, ScanStringFunctionVariableArgsInMethod) {
+	EACH_PARSER() {
+		// check that default arguments does not prevent variable argument detection.
+		Parser->SetClassMemberObserver(Observer);
+		UnicodeString code = _U(
+
+			// test variable argument detection inside a method
+			"namespace App;\n"
+			"class ActionClass {\n"
+			"  /** @param $tag */\n"
+			"  protected function do_action($tag) {\n"
+			"    $args = func_get_args();\n"
+			"  }\n"
+			"}\n"
+		);
+
+		CHECK(Parser->ScanString(code, *LintResults));
+		CHECK_UNISTR_EQUALS("", LintResults->Error);
+
+		CHECK_VECTOR_SIZE(1, Observer->MethodSignature);
+		CHECK_UNISTR_EQUALS("protected function do_action($tag)", Observer->MethodSignature[0]);
+
+		CHECK_VECTOR_SIZE(1, Observer->MethodHasVariableArguments);
+		CHECK(Observer->MethodHasVariableArguments[0]);
+	}
+}
+
 TEST_FIXTURE(ParserStringSharedTestClass, ScanStringMethodVariableArgsWithExpressionObserver) {
 	EACH_PARSER() {	
 		// when adding the expression observer an entirely different parser


### PR DESCRIPTION
Since PHP fallbacks to global functions, we need to look for
unqualified name usages of "func_get_args"